### PR TITLE
CI: Add Copilot PR review automation

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,35 @@
+name: Request Copilot PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  copilot-review:
+    runs-on: ubuntu-latest
+    name: Copilot Code Review
+    steps:
+      - name: Request Copilot Code Review
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Request Copilot as a reviewer
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              reviewers: ['copilot']
+            }).catch(err => {
+              // Copilot may not be available; post a comment instead
+              github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: '@github-copilot review'
+              });
+            });


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow to automatically request Copilot code reviews on PR creation and updates.

## Changes

**.github/workflows/copilot-review.yml**:
- Triggers on PR open and synchronize (updates)
- Requests Copilot as a reviewer via GitHub API
- Fallback to @github-copilot mention if direct assignment unavailable
- Uses standard GitHub token (no additional secrets required)

## Benefits

- Copilot reviews PRs automatically without manual request
- Consistent with user's code review workflow (CodeRabbit, Copilot already being used)
- No configuration needed, works out of the box
- Integrates with existing GitHub branch protection requirements