### PR TITLE
fix: Always trigger Copilot review via comment

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // Request Copilot as a reviewer using the official bot identifier
+            // Add Copilot as reviewer (for visibility)
             try {
               const result = await github.rest.pulls.requestReviewers({
                 owner: context.repo.owner,
@@ -34,24 +34,24 @@ jobs:
                 pull_number: context.issue.number,
                 reviewers: ['copilot-pull-request-reviewer[bot]']
               });
-              console.log('Successfully requested Copilot review:', result.status);
+              console.log('Added Copilot as reviewer:', result.status);
             } catch (err) {
               const errMsg = err instanceof Error ? err.message : String(err);
-              const errStatus = typeof err === 'object' && err !== null && 'status' in err ? err.status : 'unknown';
-              console.log(`Failed to add Copilot reviewer: status=${errStatus}, message=${errMsg}`);
-              // Post comment mentioning github-copilot for manual review
-              try {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  body: '@github-copilot review'
-                });
-                console.log('Posted @github-copilot review comment as fallback');
-              } catch (commentErr) {
-                const commentErrMsg = commentErr instanceof Error ? commentErr.message : String(commentErr);
-                const commentErrStatus = typeof commentErr === 'object' && commentErr !== null && 'status' in commentErr ? commentErr.status : 'unknown';
-                console.log(`Failed to post comment: status=${commentErrStatus}, message=${commentErrMsg}`);
-                throw commentErr;
-              }
+              console.log(`Note: Could not add Copilot as reviewer: ${errMsg}`);
+            }
+
+            // Trigger Copilot review via comment (this actually starts the review)
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: '@github-copilot review'
+              });
+              console.log('Triggered Copilot review via comment');
+            } catch (commentErr) {
+              const commentErrMsg = commentErr instanceof Error ? commentErr.message : String(commentErr);
+              const commentErrStatus = typeof commentErr === 'object' && commentErr !== null && 'status' in commentErr ? commentErr.status : 'unknown';
+              console.log(`Failed to trigger Copilot review: status=${commentErrStatus}, message=${commentErrMsg}`);
+              throw commentErr;
             }


### PR DESCRIPTION
## Problem

The Copilot review workflow was not reliably triggering reviews. Investigation showed:

- The `requestReviewers` API call only adds Copilot to the reviewer list
- It does NOT trigger Copilot to actually start reviewing  
- The `@github-copilot review` comment is what actually triggers the review
- Previously, this comment was only posted as a fallback if the API call failed

**Result**: Copilot was added as a reviewer, but reviews never auto-triggered. Users had to manually click "Request Review" on Copilot each time.

## Solution

Always post the `@github-copilot review` comment (the actual trigger mechanism) directly, making it the primary way to trigger reviews. The `requestReviewers` call is kept for visibility in the reviewer list, but the comment is what actually starts the review.

## Changes

- Split reviewer-adding and review-triggering into two separate, independent steps
- Comment is always posted (not just on error)
- Clearer logging: "Added as reviewer" vs "Triggered review"

## Test

- PR #32 had to manually trigger Copilot (with old workflow)
- After this fix, Copilot will auto-review on next PR

Resolves: Copilot review not automatically triggering

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>