### PR TITLE
feat: smoke test tagging & pre-commit strategy

### DIFF
--- a/.github/workflows/coverage-gates.yml
+++ b/.github/workflows/coverage-gates.yml
@@ -33,7 +33,6 @@ jobs:
         run: periphery scan
   smoke:
     runs-on: macos-15
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Smoke tests

--- a/.github/workflows/coverage-gates.yml
+++ b/.github/workflows/coverage-gates.yml
@@ -31,6 +31,13 @@ jobs:
       - name: Periphery (dead code)
         continue-on-error: true
         run: periphery scan
+  smoke:
+    runs-on: macos-15
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Smoke tests
+        run: swift test --filter testSmoke 2>&1 | xcbeautify; exit ${PIPESTATUS[0]}
   coverage:
     runs-on: macos-15
     continue-on-error: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@ swift run notes-cli seed --db ./data/notes.sqlite  # Seed data
 
 # Test
 swift test                                     # Full suite
+swift test --filter testSmoke                  # Smoke subset (~164 tests, <10s)
+./Scripts/run-smoke-tests.sh                   # Smoke tests (script wrapper)
 swift test NotesUITests                        # Single target
 swift test --filter NotesUITests.AppViewModelTests.testDeleteNote  # Single test
 
@@ -54,11 +56,12 @@ Before committing ANY code, complete in order:
 
 1. **Build**: `swift build` succeeds
 2. **Lint**: `./Scripts/run-lint.sh` passes
-3. **Tests**: `swift test` — all pass
-4. **Coverage**: `./Scripts/run-coverage-gates.sh` passes
-5. **Perf** (if perf-sensitive): `./Scripts/run-perf-gates.sh` passes
-6. **Diff review**: `git diff --staged` — check for incomplete refactors, debug prints, missing tests
-7. **Commit**: conventional commit format only after steps 1-6 pass
+3. **Smoke tests**: `swift test --filter testSmoke` — fast subset passes (pre-commit hook runs this automatically)
+4. **Tests**: `swift test` — all pass
+5. **Coverage**: `./Scripts/run-coverage-gates.sh` passes
+6. **Perf** (if perf-sensitive): `./Scripts/run-perf-gates.sh` passes
+7. **Diff review**: `git diff --staged` — check for incomplete refactors, debug prints, missing tests
+8. **Commit**: conventional commit format only after steps 1-7 pass
 
 See `Docs/testing.md` for the full code review protocol and multi-step plan discipline.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ swift run notes-cli seed --db ./data/notes.sqlite  # Seed data
 
 # Test
 swift test                                     # Full suite
-swift test --filter testSmoke                  # Smoke subset (~164 tests, <10s)
+swift test --filter testSmoke                  # Smoke subset (~160 tests, <10s)
 ./Scripts/run-smoke-tests.sh                   # Smoke tests (script wrapper)
 swift test NotesUITests                        # Single target
 swift test --filter NotesUITests.AppViewModelTests.testDeleteNote  # Single test

--- a/Scripts/run-smoke-tests.sh
+++ b/Scripts/run-smoke-tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 echo "==> Smoke tests"
-swift test --filter testSmoke 2>&1 | tail -3
+swift test --filter testSmoke
 echo "✓ Smoke tests passed"

--- a/Scripts/run-smoke-tests.sh
+++ b/Scripts/run-smoke-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "==> Smoke tests"
+swift test --filter testSmoke 2>&1 | tail -3
+echo "✓ Smoke tests passed"

--- a/Tests/NotesDomainTests/DomainErrorsAndModelsTests.swift
+++ b/Tests/NotesDomainTests/DomainErrorsAndModelsTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import NotesDomain
 
 final class DomainErrorsAndModelsTests: XCTestCase {
-    func testDomainValidationErrorDescriptions() {
+    func testSmoke_DomainValidationErrorDescriptions() {
         XCTAssertEqual(
             DomainValidationError.invalidPriority(9).errorDescription,
             "Task priority must be between 0 and 5, got 9.",
@@ -18,7 +18,7 @@ final class DomainErrorsAndModelsTests: XCTestCase {
         )
     }
 
-    func testStorageErrorDescriptions() {
+    func testSmoke_StorageErrorDescriptions() {
         XCTAssertEqual(
             StorageError.openDatabase(path: "/tmp/db", reason: "no permission").errorDescription,
             "Failed to open SQLite database at /tmp/db: no permission",
@@ -41,7 +41,7 @@ final class DomainErrorsAndModelsTests: XCTestCase {
         )
     }
 
-    func testSyncErrorDescriptions() {
+    func testSmoke_SyncErrorDescriptions() {
         XCTAssertEqual(
             SyncError.missingEventIdentifier.errorDescription,
             "Calendar provider did not return an event identifier; cannot persist binding.",
@@ -52,7 +52,7 @@ final class DomainErrorsAndModelsTests: XCTestCase {
         )
     }
 
-    func testCalendarProviderErrorDescriptionsAndRetryability() {
+    func testSmoke_CalendarProviderErrorDescriptionsAndRetryability() {
         XCTAssertEqual(
             CalendarProviderError.transient(reason: "timeout").errorDescription,
             "Transient calendar provider failure: timeout",
@@ -65,7 +65,7 @@ final class DomainErrorsAndModelsTests: XCTestCase {
         XCTAssertFalse(CalendarProviderError.permanent(reason: "x").isRetryable)
     }
 
-    func testTaskValidationFailsInvalidPriority() {
+    func testSmoke_TaskValidationFailsInvalidPriority() {
         XCTAssertThrowsError(
             try Task(stableID: "id", title: "Task", priority: 10, updatedAt: Date()),
         ) { error in
@@ -73,7 +73,7 @@ final class DomainErrorsAndModelsTests: XCTestCase {
         }
     }
 
-    func testTaskValidationFailsInvalidRange() {
+    func testSmoke_TaskValidationFailsInvalidRange() {
         XCTAssertThrowsError(
             try Task(
                 stableID: "id",
@@ -87,7 +87,7 @@ final class DomainErrorsAndModelsTests: XCTestCase {
         }
     }
 
-    func testCalendarEventValidationFailsInvalidRange() {
+    func testSmoke_CalendarEventValidationFailsInvalidRange() {
         XCTAssertThrowsError(
             try CalendarEvent(
                 calendarID: "calendar",
@@ -101,7 +101,7 @@ final class DomainErrorsAndModelsTests: XCTestCase {
         }
     }
 
-    func testTaskSortOrderAllCases() {
+    func testSmoke_TaskSortOrderAllCases() {
         let allCases = TaskSortOrder.allCases
         XCTAssertEqual(allCases.count, 4)
         XCTAssertTrue(allCases.contains(.dueDate))
@@ -110,14 +110,14 @@ final class DomainErrorsAndModelsTests: XCTestCase {
         XCTAssertTrue(allCases.contains(.creationDate))
     }
 
-    func testTaskSortOrderTitleProperty() {
+    func testSmoke_TaskSortOrderTitleProperty() {
         XCTAssertEqual(TaskSortOrder.dueDate.title, "Due Date")
         XCTAssertEqual(TaskSortOrder.priority.title, "Priority")
         XCTAssertEqual(TaskSortOrder.title.title, "Title")
         XCTAssertEqual(TaskSortOrder.creationDate.title, "Date Added")
     }
 
-    func testTaskSortOrderCodable() throws {
+    func testSmoke_TaskSortOrderCodable() throws {
         let cases: [TaskSortOrder] = [.dueDate, .priority, .title, .creationDate]
         for sortOrder in cases {
             let encoded = try JSONEncoder().encode(sortOrder)
@@ -126,7 +126,7 @@ final class DomainErrorsAndModelsTests: XCTestCase {
         }
     }
 
-    func testTaskSortOrderRawValue() {
+    func testSmoke_TaskSortOrderRawValue() {
         XCTAssertEqual(TaskSortOrder.dueDate.rawValue, "dueDate")
         XCTAssertEqual(TaskSortOrder.priority.rawValue, "priority")
         XCTAssertEqual(TaskSortOrder.title.rawValue, "title")

--- a/Tests/NotesFeatureTests/NotificationSchedulerTests.swift
+++ b/Tests/NotesFeatureTests/NotificationSchedulerTests.swift
@@ -34,14 +34,14 @@ final class NotificationSchedulerTests: XCTestCase {
         scheduler = MockNotificationScheduler()
     }
 
-    func testRequestAuthorizationReturnsTrue() async {
+    func testSmoke_RequestAuthorizationReturnsTrue() async {
         let result = await scheduler.requestAuthorization()
         XCTAssertTrue(result)
         let authed = await scheduler.authorizationRequested
         XCTAssertTrue(authed)
     }
 
-    func testScheduleReminderAppendsTaskID() async throws {
+    func testSmoke_ScheduleReminderAppendsTaskID() async throws {
         let task = try Task(
             noteID: nil,
             stableID: "test",
@@ -56,14 +56,14 @@ final class NotificationSchedulerTests: XCTestCase {
         XCTAssertTrue(scheduled.contains(task.id))
     }
 
-    func testCancelReminderAppendsTaskID() async {
+    func testSmoke_CancelReminderAppendsTaskID() async {
         let taskID = UUID()
         await scheduler.cancelReminder(for: taskID)
         let cancelled = await scheduler.cancelledTaskIDs
         XCTAssertTrue(cancelled.contains(taskID))
     }
 
-    func testCancelAllRemindersClears() async {
+    func testSmoke_CancelAllRemindersClears() async {
         let id1 = UUID()
         let id2 = UUID()
         await scheduler.cancelReminder(for: id1)

--- a/Tests/NotesFeaturesTests/DailyNoteTests.swift
+++ b/Tests/NotesFeaturesTests/DailyNoteTests.swift
@@ -17,7 +17,7 @@ final class DailyNoteTests: XCTestCase {
         super.tearDown()
     }
 
-    func testCreatesWithISODateTitle() async throws {
+    func testSmoke_CreatesWithISODateTitle() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
         let service = WorkspaceService(store: store)
 
@@ -32,7 +32,7 @@ final class DailyNoteTests: XCTestCase {
         XCTAssertEqual(note.title, expectedTitle)
     }
 
-    func testIdempotentOnSameDay() async throws {
+    func testSmoke_IdempotentOnSameDay() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
         let service = WorkspaceService(store: store)
 

--- a/Tests/NotesFeaturesTests/FuzzyMatcherTests.swift
+++ b/Tests/NotesFeaturesTests/FuzzyMatcherTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class FuzzyMatcherTests: XCTestCase {
     private let matcher = FuzzyMatcher()
 
-    func testExactMatchRanksFirst() {
+    func testSmoke_ExactMatchRanksFirst() {
         let candidates = ["Alpha", "alpha project", "Alphanumeric"]
         let results = matcher.rank(query: "Alpha", candidates: candidates)
         XCTAssertEqual(results.first?.title, "Alpha")
@@ -30,7 +30,7 @@ final class FuzzyMatcherTests: XCTestCase {
         XCTAssertGreaterThan(results[0].score, results[1].score)
     }
 
-    func testNonMatchExcluded() {
+    func testSmoke_NonMatchExcluded() {
         let candidates = ["Alpha", "Beta", "Gamma"]
         let results = matcher.rank(query: "Zeta", candidates: candidates)
         XCTAssertTrue(results.isEmpty)
@@ -43,7 +43,7 @@ final class FuzzyMatcherTests: XCTestCase {
         XCTAssertEqual(results.map(\.title), ["Alpha", "Beta", "Gamma"])
     }
 
-    func testCaseInsensitive() {
+    func testSmoke_CaseInsensitive() {
         let candidates = ["ALPHA", "alpha", "Alpha"]
         let results = matcher.rank(query: "alpha", candidates: candidates)
         XCTAssertEqual(results.count, 3)

--- a/Tests/NotesFeaturesTests/GraphEdgesTests.swift
+++ b/Tests/NotesFeaturesTests/GraphEdgesTests.swift
@@ -17,7 +17,7 @@ final class GraphEdgesTests: XCTestCase {
         super.tearDown()
     }
 
-    func testResolvesWikiLinksToEdges() async throws {
+    func testSmoke_ResolvesWikiLinksToEdges() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
         let service = WorkspaceService(store: store)
 
@@ -57,7 +57,7 @@ final class GraphEdgesTests: XCTestCase {
         XCTAssertEqual(edges.count, 0)
     }
 
-    func testEmptyStoreReturnsNoEdges() async throws {
+    func testSmoke_EmptyStoreReturnsNoEdges() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
         let service = WorkspaceService(store: store)
 

--- a/Tests/NotesFeaturesTests/TagParserTests.swift
+++ b/Tests/NotesFeaturesTests/TagParserTests.swift
@@ -4,12 +4,12 @@ import XCTest
 final class TagParserTests: XCTestCase {
     private let parser = TagParser()
 
-    func testExtractsSingleTag() {
+    func testSmoke_ExtractsSingleTag() {
         let tags = parser.extractTags(from: "Hello #world")
         XCTAssertEqual(tags, ["world"])
     }
 
-    func testExtractsMultipleTags() {
+    func testSmoke_ExtractsMultipleTags() {
         let tags = parser.extractTags(from: "#first some text #second")
         XCTAssertEqual(tags, ["first", "second"])
     }
@@ -24,7 +24,7 @@ final class TagParserTests: XCTestCase {
         XCTAssertEqual(tags, ["hello"])
     }
 
-    func testIgnoresEmbeddedHash() {
+    func testSmoke_IgnoresEmbeddedHash() {
         let tags = parser.extractTags(from: "text#notag but #real")
         XCTAssertEqual(tags, ["real"])
     }
@@ -34,7 +34,7 @@ final class TagParserTests: XCTestCase {
         XCTAssertEqual(tags, ["project/sub-task"])
     }
 
-    func testEmptyBodyReturnsEmpty() {
+    func testSmoke_EmptyBodyReturnsEmpty() {
         let tags = parser.extractTags(from: "")
         XCTAssertTrue(tags.isEmpty)
     }

--- a/Tests/NotesFeaturesTests/TemplateTests.swift
+++ b/Tests/NotesFeaturesTests/TemplateTests.swift
@@ -17,7 +17,7 @@ final class TemplateTests: XCTestCase {
         super.tearDown()
     }
 
-    func testCRUDTemplates() async throws {
+    func testSmoke_CRUDTemplates() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
         let service = WorkspaceService(store: store)
 
@@ -46,7 +46,7 @@ final class TemplateTests: XCTestCase {
         }
     }
 
-    func testCreateNoteUsesTemplateBody() async throws {
+    func testSmoke_CreateNoteUsesTemplateBody() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
         let service = WorkspaceService(store: store)
 

--- a/Tests/NotesFeaturesTests/UnlinkedMentionsTests.swift
+++ b/Tests/NotesFeaturesTests/UnlinkedMentionsTests.swift
@@ -17,7 +17,7 @@ final class UnlinkedMentionsTests: XCTestCase {
         super.tearDown()
     }
 
-    func testDetectsPlainTextMentions() async throws {
+    func testSmoke_DetectsPlainTextMentions() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
         let service = WorkspaceService(store: store)
 
@@ -31,7 +31,7 @@ final class UnlinkedMentionsTests: XCTestCase {
         XCTAssertEqual(mentions[0].sourceTitle, "Source Note")
     }
 
-    func testExcludesExistingBacklinks() async throws {
+    func testSmoke_ExcludesExistingBacklinks() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
         let service = WorkspaceService(store: store)
 

--- a/Tests/NotesFeaturesTests/WorkspaceServiceTests.swift
+++ b/Tests/NotesFeaturesTests/WorkspaceServiceTests.swift
@@ -20,7 +20,7 @@ final class WorkspaceServiceTests: XCTestCase {
         XCTAssertEqual(links, ["Q2 Launch Plan", "Vendor Call Notes", "Team Sync"])
     }
 
-    func testBacklinksAreResolvedCaseInsensitively() async throws {
+    func testSmoke_BacklinksAreResolvedCaseInsensitively() async throws {
         let store = try makeStore()
         let service = WorkspaceService(
             taskStore: store,
@@ -66,7 +66,7 @@ final class WorkspaceServiceTests: XCTestCase {
         XCTAssertTrue(backlinks.isEmpty)
     }
 
-    func testSearchNotesReturnsFTSMatches() async throws {
+    func testSmoke_SearchNotesReturnsFTSMatches() async throws {
         let service = try makeService(now: Date(timeIntervalSince1970: 1_700_000_000))
 
         _ = try await service.createNote(title: "Roadmap", body: "Discuss FTS launch milestones")
@@ -290,7 +290,7 @@ final class WorkspaceServiceTests: XCTestCase {
         XCTAssertTrue(imported.contains { $0.stableID == "from-calendar" })
     }
 
-    func testSeedDemoDataCreatesNotesAndTasksOnce() async throws {
+    func testSmoke_SeedDemoDataCreatesNotesAndTasksOnce() async throws {
         let service = try makeService(now: Date(timeIntervalSince1970: 1_700_000_000))
 
         try await service.seedDemoDataIfNeeded()

--- a/Tests/NotesStorageTests/SQLiteKanbanColumnTests.swift
+++ b/Tests/NotesStorageTests/SQLiteKanbanColumnTests.swift
@@ -16,7 +16,7 @@ final class SQLiteKanbanColumnTests: XCTestCase {
         super.tearDown()
     }
 
-    func testFetchColumnsReturnsSeededDefaults() async throws {
+    func testSmoke_FetchColumnsReturnsSeededDefaults() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
 
         let columns = try await store.fetchColumns()
@@ -30,7 +30,7 @@ final class SQLiteKanbanColumnTests: XCTestCase {
         XCTAssertEqual(columns.map(\.position), [0, 1, 2, 3, 4])
     }
 
-    func testUpsertCustomColumn() async throws {
+    func testSmoke_UpsertCustomColumn() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
 
         let column = KanbanColumn(title: "Review", position: 5, wipLimit: 3, colorHex: "#FF5500")
@@ -46,7 +46,7 @@ final class SQLiteKanbanColumnTests: XCTestCase {
         XCTAssertNil(custom?.builtInStatus)
     }
 
-    func testDeleteCustomColumn() async throws {
+    func testSmoke_DeleteCustomColumn() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
 
         let column = KanbanColumn(title: "Custom", position: 5)
@@ -87,7 +87,7 @@ final class SQLiteKanbanColumnTests: XCTestCase {
         XCTAssertEqual(fetched?.labels.last?.name, "Feature")
     }
 
-    func testTaskKanbanColumnIDPersistence() async throws {
+    func testSmoke_TaskKanbanColumnIDPersistence() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
 
         let column = KanbanColumn(title: "Custom", position: 5)

--- a/Tests/NotesStorageTests/SQLiteStoreTests.swift
+++ b/Tests/NotesStorageTests/SQLiteStoreTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import NotesStorage
 
 final class SQLiteStoreTests: XCTestCase {
-    func testUpsertAndFetchNote() async throws {
+    func testSmoke_UpsertAndFetchNote() async throws {
         let store = try makeStore()
 
         let note = Note(
@@ -21,7 +21,7 @@ final class SQLiteStoreTests: XCTestCase {
         XCTAssertGreaterThan(persisted.version, 0)
     }
 
-    func testUpsertAndFetchTask() async throws {
+    func testSmoke_UpsertAndFetchTask() async throws {
         let store = try makeStore()
 
         let task = try Task(
@@ -45,7 +45,7 @@ final class SQLiteStoreTests: XCTestCase {
         XCTAssertGreaterThan(persisted.version, 0)
     }
 
-    func testStableIDPreventsDuplicatesAcrossEdits() async throws {
+    func testSmoke_StableIDPreventsDuplicatesAcrossEdits() async throws {
         let store = try makeStore()
         let first = try Task(
             id: UUID(),
@@ -71,7 +71,7 @@ final class SQLiteStoreTests: XCTestCase {
         XCTAssertEqual(fetched?.title, "Edited title")
     }
 
-    func testUpsertTaskPersistsKanbanOrder() async throws {
+    func testSmoke_UpsertTaskPersistsKanbanOrder() async throws {
         let store = try makeStore()
         let task = try Task(
             stableID: "task-kanban-order",
@@ -88,7 +88,7 @@ final class SQLiteStoreTests: XCTestCase {
         XCTAssertEqual(fetched?.kanbanOrder, 42.5)
     }
 
-    func testTombstoneMarksDeletedAndIncrementsVersion() async throws {
+    func testSmoke_TombstoneMarksDeletedAndIncrementsVersion() async throws {
         let store = try makeStore()
 
         let task = try Task(

--- a/Tests/NotesStorageTests/SQLiteTemplateStoreTests.swift
+++ b/Tests/NotesStorageTests/SQLiteTemplateStoreTests.swift
@@ -24,7 +24,7 @@ final class SQLiteTemplateStoreTests: XCTestCase {
         XCTAssertEqual(templates.count, 0)
     }
 
-    func testUpsertAndFetch() async throws {
+    func testSmoke_UpsertAndFetch() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
 
         let template = NoteTemplate(name: "Test", body: "Body", createdAt: Date())
@@ -37,7 +37,7 @@ final class SQLiteTemplateStoreTests: XCTestCase {
         XCTAssertEqual(fetched[0].body, "Body")
     }
 
-    func testUpdate() async throws {
+    func testSmoke_Update() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
 
         let template = NoteTemplate(name: "Test", body: "Body", createdAt: Date())
@@ -52,7 +52,7 @@ final class SQLiteTemplateStoreTests: XCTestCase {
         XCTAssertEqual(fetched[0].body, "Updated Body")
     }
 
-    func testDelete() async throws {
+    func testSmoke_Delete() async throws {
         let store = try SQLiteStore(databaseURL: tempDir.appendingPathComponent("test.db"))
 
         let template = NoteTemplate(name: "Test", body: "Body", createdAt: Date())

--- a/Tests/NotesSyncTests/EventKitCalendarProviderTests.swift
+++ b/Tests/NotesSyncTests/EventKitCalendarProviderTests.swift
@@ -5,7 +5,7 @@
     @testable import NotesSync
 
     final class EventKitCalendarProviderTests: XCTestCase {
-        func testUpsertThrowsWhenAccessDenied() async throws {
+        func testSmoke_UpsertThrowsWhenAccessDenied() async throws {
             let client = FakeEventStoreClient()
             await client.setAuthorization(.other)
             await client.setAccessResult(.success(false))
@@ -41,7 +41,7 @@
             }
         }
 
-        func testUpsertExistingEventAddsRecurrenceMarkerAndPersists() async throws {
+        func testSmoke_UpsertExistingEventAddsRecurrenceMarkerAndPersists() async throws {
             let client = FakeEventStoreClient()
             await client.setAuthorization(.fullAccess)
             await client.addCalendar(id: "cal-1")
@@ -110,7 +110,7 @@
             XCTAssertEqual(interval, 86400, accuracy: 1)
         }
 
-        func testDeleteNoopWhenEventMissing() async throws {
+        func testSmoke_DeleteNoopWhenEventMissing() async throws {
             let client = FakeEventStoreClient()
             await client.setAuthorization(.fullAccess)
             await client.addCalendar(id: "cal-1")
@@ -147,7 +147,7 @@
             XCTAssertEqual(removed, [])
         }
 
-        func testFetchChangesDetectsUpsertsAndDeletions() async throws {
+        func testSmoke_FetchChangesDetectsUpsertsAndDeletions() async throws {
             let client = FakeEventStoreClient()
             await client.setAuthorization(.fullAccess)
             await client.addCalendar(id: "cal-1")

--- a/Tests/NotesSyncTests/TaskCalendarMapperTests.swift
+++ b/Tests/NotesSyncTests/TaskCalendarMapperTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class TaskCalendarMapperTests: XCTestCase {
     private let mapper = TaskCalendarMapper()
 
-    func testEventFromTaskAddsStableIDMarkerWhenDetailsEmpty() throws {
+    func testSmoke_EventFromTaskAddsStableIDMarkerWhenDetailsEmpty() throws {
         let task = try Task(stableID: "stable-1", title: "Task", details: "", updatedAt: Date())
         let event = try mapper.event(from: task, calendarID: "cal", existing: nil)
 
@@ -34,7 +34,7 @@ final class TaskCalendarMapperTests: XCTestCase {
         XCTAssertEqual(markerCount, 2)
     }
 
-    func testTaskFromEventUsesSourceStableIDFirst() throws {
+    func testSmoke_TaskFromEventUsesSourceStableIDFirst() throws {
         let event = try CalendarEvent(
             calendarID: "cal",
             title: "E",
@@ -82,14 +82,14 @@ final class TaskCalendarMapperTests: XCTestCase {
         XCTAssertEqual(task.stableID, "existing")
     }
 
-    func testTaskFromEventCreatesGeneratedStableID() throws {
+    func testSmoke_TaskFromEventCreatesGeneratedStableID() throws {
         let event = try CalendarEvent(calendarID: "cal", title: "E", notes: nil, updatedAt: Date())
         let task = try mapper.task(from: event, existingTask: nil)
 
         XCTAssertFalse(task.stableID.isEmpty)
     }
 
-    func testTaskFromEventMarksCompletedState() throws {
+    func testSmoke_TaskFromEventMarksCompletedState() throws {
         let event = try CalendarEvent(
             calendarID: "cal",
             title: "E",
@@ -153,7 +153,7 @@ final class TaskCalendarMapperTests: XCTestCase {
         XCTAssertNil(TaskCalendarMapper.recurrenceExceptionDate(in: stripped))
     }
 
-    func testResolveWithoutBindingReturnsEventWins() throws {
+    func testSmoke_ResolveWithoutBindingReturnsEventWins() throws {
         let task = try makeTask(updatedAt: 100, stableID: "s", title: "task")
         let event = try makeEvent(updatedAt: 100, sourceStableID: "s", title: "event")
 
@@ -275,7 +275,7 @@ final class TaskCalendarMapperTests: XCTestCase {
         }
     }
 
-    func testResolvePolicyLastWriteWinsWhenEventNewer() throws {
+    func testSmoke_ResolvePolicyLastWriteWinsWhenEventNewer() throws {
         let task = try makeTask(updatedAt: 250, stableID: "s", title: "task")
         let event = try makeEvent(updatedAt: 260, sourceStableID: "s", title: "event")
         let binding = CalendarBinding(

--- a/Tests/NotesSyncTests/TwoWaySyncEngineEdgeCaseTests.swift
+++ b/Tests/NotesSyncTests/TwoWaySyncEngineEdgeCaseTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @testable import NotesSync
 
 final class TwoWaySyncEngineEdgeCaseTests: XCTestCase {
-    func testRunOnceThrowsWhenUpsertEventHasNoIdentifier() async throws {
+    func testSmoke_RunOnceThrowsWhenUpsertEventHasNoIdentifier() async throws {
         let store = try makeStore()
         let provider = StubCalendarProvider()
 
@@ -33,7 +33,7 @@ final class TwoWaySyncEngineEdgeCaseTests: XCTestCase {
         }
     }
 
-    func testRunOnceRetriesTransientUpsertAndCapturesDiagnostic() async throws {
+    func testSmoke_RunOnceRetriesTransientUpsertAndCapturesDiagnostic() async throws {
         let store = try makeStore()
         let provider = StubCalendarProvider()
 

--- a/Tests/NotesSyncTests/TwoWaySyncEngineTests.swift
+++ b/Tests/NotesSyncTests/TwoWaySyncEngineTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import NotesSync
 
 final class TwoWaySyncEngineTests: XCTestCase {
-    func testRunOncePushesTaskAndCreatesBinding() async throws {
+    func testSmoke_RunOncePushesTaskAndCreatesBinding() async throws {
         let store = try makeStore()
         let provider = InMemoryCalendarProvider()
 
@@ -46,7 +46,7 @@ final class TwoWaySyncEngineTests: XCTestCase {
         XCTAssertEqual(eventCount, 1)
     }
 
-    func testRunOnceImportsCalendarEventAsTask() async throws {
+    func testSmoke_RunOnceImportsCalendarEventAsTask() async throws {
         let store = try makeStore()
         let provider = InMemoryCalendarProvider()
 
@@ -90,7 +90,7 @@ final class TwoWaySyncEngineTests: XCTestCase {
         XCTAssertNotNil(binding)
     }
 
-    func testCalendarDeletionCreatesTaskTombstone() async throws {
+    func testSmoke_CalendarDeletionCreatesTaskTombstone() async throws {
         let store = try makeStore()
         let provider = InMemoryCalendarProvider()
 

--- a/Tests/NotesUITests/AppViewModelTests.swift
+++ b/Tests/NotesUITests/AppViewModelTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 @MainActor
 final class AppViewModelTests: XCTestCase {
-    func testLoadSeedsAndSelectsFirstNote() async {
+    func testSmoke_LoadSeedsAndSelectsFirstNote() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
 
@@ -31,7 +31,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isBusy)
     }
 
-    func testCreateNoteSelectsCreatedNote() async {
+    func testSmoke_CreateNoteSelectsCreatedNote() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -52,7 +52,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertEqual(updateCalls, 0)
     }
 
-    func testSaveSelectedNotePersistsChanges() async {
+    func testSmoke_SaveSelectedNotePersistsChanges() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -66,7 +66,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.notes.first?.title, "Alpha Updated")
     }
 
-    func testSelectNoteNilClearsEditor() async {
+    func testSmoke_SelectNoteNilClearsEditor() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -91,7 +91,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertEqual(createCalls, 0)
     }
 
-    func testCreateQuickTaskCreatesTaskAndClearsField() async {
+    func testSmoke_CreateQuickTaskCreatesTaskAndClearsField() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -105,7 +105,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.tasks.contains { $0.title == "Ship draft" })
     }
 
-    func testSetTaskFilterReloadsTasks() async {
+    func testSmoke_SetTaskFilterReloadsTasks() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -117,7 +117,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tasks.first?.status, .done)
     }
 
-    func testSetNoteSearchQueryFiltersAndClearsSelectionWhenMissing() async {
+    func testSmoke_SetNoteSearchQueryFiltersAndClearsSelectionWhenMissing() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -159,7 +159,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isWikiLinkSuggestionVisible)
     }
 
-    func testQuickOpenFiltersAndSelectsNote() async {
+    func testSmoke_QuickOpenFiltersAndSelectsNote() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -180,7 +180,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedNoteID, target.id)
     }
 
-    func testMarkdownInsertActionsAppendExpectedPrefixes() async {
+    func testSmoke_MarkdownInsertActionsAppendExpectedPrefixes() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -213,7 +213,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.noteSearchSnippet(for: firstID))
     }
 
-    func testHandleTaskDropMovesTaskToTargetStatus() async {
+    func testSmoke_HandleTaskDropMovesTaskToTargetStatus() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -494,7 +494,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tasks.first(where: { $0.id == backlogA.id })?.status, .backlog)
     }
 
-    func testToggleTaskCompletionUpdatesTaskState() async {
+    func testSmoke_ToggleTaskCompletionUpdatesTaskState() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -509,7 +509,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.tasks.contains { $0.id == first.id && $0.status == .done })
     }
 
-    func testMoveTaskUpdatesStatus() async {
+    func testSmoke_MoveTaskUpdatesStatus() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -655,7 +655,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.errorMessage, "Could not resolve a parent recurring series for this occurrence.")
     }
 
-    func testDeleteTaskRemovesTaskWithoutPromptWhenNotDetached() async {
+    func testSmoke_DeleteTaskRemovesTaskWithoutPromptWhenNotDetached() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -763,7 +763,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isSyncing)
     }
 
-    func testRunSyncSuccessStoresReport() async {
+    func testSmoke_RunSyncSuccessStoresReport() async {
         let service = WorkspaceServiceSpy()
         let provider = InMemoryCalendarProvider()
         let viewModel = AppViewModel(service: service, calendarProviderFactory: { provider }, syncCalendarID: "cal")
@@ -802,7 +802,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.recurrenceConflictMessage)
     }
 
-    func testRunSyncFailureSetsErrorAndStopsSync() async {
+    func testSmoke_RunSyncFailureSetsErrorAndStopsSync() async {
         let service = WorkspaceServiceSpy()
         await service.setFailure(.sync)
         let provider = InMemoryCalendarProvider()
@@ -856,7 +856,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.lastDiagnosticsExportURL)
     }
 
-    func testNavigateToNoteByTitleSelectsCorrectNote() async {
+    func testSmoke_NavigateToNoteByTitleSelectsCorrectNote() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -899,7 +899,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.noteEditMode, .edit)
     }
 
-    func testToggleSwitchesToPreviewMode() async {
+    func testSmoke_ToggleSwitchesToPreviewMode() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -910,7 +910,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.renderedMarkdown.characters.isEmpty || viewModel.selectedNoteBody.isEmpty)
     }
 
-    func testToggleRoundTrips() async {
+    func testSmoke_ToggleRoundTrips() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()
@@ -934,7 +934,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.noteEditMode, .edit)
     }
 
-    func testFilterByTagFiltersNotesList() async {
+    func testSmoke_FilterByTagFiltersNotesList() async {
         let service = WorkspaceServiceSpy()
         await service.addTaggedNote(title: "Swift Note", body: "Content", tags: ["swift"])
         await service.addTaggedNote(title: "Rust Note", body: "Content", tags: ["rust"])
@@ -961,7 +961,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(viewModel.notes.count, 2)
     }
 
-    func testAllTagsLoadedOnLoad() async {
+    func testSmoke_AllTagsLoadedOnLoad() async {
         let service = WorkspaceServiceSpy()
         await service.addTaggedNote(title: "Note", body: "Content", tags: ["alpha", "beta"])
         let viewModel = makeViewModel(service: service)
@@ -1378,7 +1378,7 @@ final class AppViewModelTests: XCTestCase {
 
     // MARK: - Kanban Column ViewModel tests
 
-    func testLoadPopulatesKanbanColumnsWithDefaults() async {
+    func testSmoke_LoadPopulatesKanbanColumnsWithDefaults() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
 
@@ -1389,7 +1389,7 @@ final class AppViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.kanbanColumns[4].builtInStatus, .done)
     }
 
-    func testCreateKanbanColumnAppendsCustomColumn() async {
+    func testSmoke_CreateKanbanColumnAppendsCustomColumn() async {
         let service = WorkspaceServiceSpy()
         let viewModel = makeViewModel(service: service)
         await viewModel.load()

--- a/Tests/NotesUITests/MarkdownRendererTests.swift
+++ b/Tests/NotesUITests/MarkdownRendererTests.swift
@@ -8,7 +8,7 @@ final class MarkdownRendererTests: XCTestCase {
         String(str[run.range].characters)
     }
 
-    func testHeadingIsBold() {
+    func testSmoke_HeadingIsBold() {
         let result = renderer.render("# Hello", noteTitles: [])
         let runs = Array(result.runs)
         XCTAssertFalse(runs.isEmpty)
@@ -33,7 +33,7 @@ final class MarkdownRendererTests: XCTestCase {
         XCTAssertTrue(italicRun?.inlinePresentationIntent?.contains(.emphasized) == true)
     }
 
-    func testBulletList() {
+    func testSmoke_BulletList() {
         let result = renderer.render("- Item A\n- Item B", noteTitles: [])
         let fullText = String(result.characters)
         XCTAssertTrue(fullText.contains("\u{2022}"))
@@ -41,7 +41,7 @@ final class MarkdownRendererTests: XCTestCase {
         XCTAssertTrue(fullText.contains("Item B"))
     }
 
-    func testWikiLinkWithExistingTitle() {
+    func testSmoke_WikiLinkWithExistingTitle() {
         let result = renderer.render("See [[Alpha]] here", noteTitles: ["Alpha"])
         let runs = Array(result.runs)
         let linkRun = runs.first { $0.link != nil }
@@ -58,7 +58,7 @@ final class MarkdownRendererTests: XCTestCase {
         XCTAssertNotNil(linkRun?.foregroundColor)
     }
 
-    func testCodeSpanMonospaced() {
+    func testSmoke_CodeSpanMonospaced() {
         let result = renderer.render("Use `code` here", noteTitles: [])
         let runs = Array(result.runs)
         let codeRun = runs.first { text(of: $0, in: result) == "code" }
@@ -66,7 +66,7 @@ final class MarkdownRendererTests: XCTestCase {
         XCTAssertTrue(codeRun?.inlinePresentationIntent?.contains(.code) == true)
     }
 
-    func testEmptyStringReturnsEmptyAttributedString() {
+    func testSmoke_EmptyStringReturnsEmptyAttributedString() {
         let result = renderer.render("", noteTitles: [])
         XCTAssertTrue(result.characters.isEmpty)
     }

--- a/Tests/NotesUITests/NotesViewsTests.swift
+++ b/Tests/NotesUITests/NotesViewsTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 @MainActor
 final class NotesViewsTests: XCTestCase {
-    func testNotesEditorContainsCoreControls() async throws {
+    func testSmoke_NotesEditorContainsCoreControls() async throws {
         let viewModel = try makeViewModel()
         await viewModel.load()
 
@@ -17,7 +17,7 @@ final class NotesViewsTests: XCTestCase {
         XCTAssertEqual(viewModel.noteEditMode, .edit, "Editor must start in edit mode")
     }
 
-    func testTasksListContainsPickerAndRows() async throws {
+    func testSmoke_TasksListContainsPickerAndRows() async throws {
         let viewModel = try makeViewModel()
         await viewModel.load()
         await viewModel.setTaskFilter(.all)
@@ -33,7 +33,7 @@ final class NotesViewsTests: XCTestCase {
         XCTAssertFalse(viewModel.tasks.isEmpty)
     }
 
-    func testKanbanRendersAllStatusColumns() async throws {
+    func testSmoke_KanbanRendersAllStatusColumns() async throws {
         let viewModel = try makeViewModel()
         await viewModel.load()
 
@@ -45,14 +45,14 @@ final class NotesViewsTests: XCTestCase {
         }
     }
 
-    func testSyncDashboardHasCalendarFieldAndRunButton() async throws {
+    func testSmoke_SyncDashboardHasCalendarFieldAndRunButton() async throws {
         let viewModel = try makeViewModel()
         await viewModel.load()
 
         XCTAssertNil(viewModel.lastSyncReport)
     }
 
-    func testNotesEditorNewNoteButtonTriggersCreation() async throws {
+    func testSmoke_NotesEditorNewNoteButtonTriggersCreation() async throws {
         let viewModel = try makeViewModel()
         await viewModel.load()
         let countBefore = viewModel.notes.count
@@ -73,7 +73,7 @@ final class NotesViewsTests: XCTestCase {
         XCTAssertNotNil(viewModel.lastSyncReport)
     }
 
-    func testKanbanMoveRightButtonTransitionsTask() async throws {
+    func testSmoke_KanbanMoveRightButtonTransitionsTask() async throws {
         let viewModel = try makeViewModel()
         await viewModel.load()
         await viewModel.setTaskFilter(.all)
@@ -238,7 +238,7 @@ final class NotesViewsTests: XCTestCase {
         XCTAssertEqual(moved?.status, .next)
     }
 
-    func testKanbanDeleteButtonRemovesTask() async throws {
+    func testSmoke_KanbanDeleteButtonRemovesTask() async throws {
         let viewModel = try makeViewModel()
         await viewModel.load()
         await viewModel.setTaskFilter(.all)
@@ -380,7 +380,7 @@ final class NotesViewsTests: XCTestCase {
         XCTAssertFalse(viewModel.tasks(for: .backlog).isEmpty, "Backlog column should still have tasks after reorder")
     }
 
-    func testSyncDashboardShowsReportSectionAfterSync() async throws {
+    func testSmoke_SyncDashboardShowsReportSectionAfterSync() async throws {
         let viewModel = try makeViewModel()
         await viewModel.load()
 
@@ -422,14 +422,14 @@ final class NotesViewsTests: XCTestCase {
         try makeTestAppViewModel()
     }
 
-    func testTogglePreviewButtonRenders() async throws {
+    func testSmoke_TogglePreviewButtonRenders() async throws {
         let viewModel = try makeViewModel()
         await viewModel.load()
 
         XCTAssertEqual(viewModel.noteEditMode, .edit)
     }
 
-    func testPreviewModeShowsPreviewNotEditor() async throws {
+    func testSmoke_PreviewModeShowsPreviewNotEditor() async throws {
         let viewModel = try makeViewModel()
         await viewModel.load()
 
@@ -448,7 +448,7 @@ final class NotesViewsTests: XCTestCase {
         XCTAssertEqual(viewModel.noteEditMode, .edit)
     }
 
-    func testTagFilterBarRendersWithTags() async throws {
+    func testSmoke_TagFilterBarRendersWithTags() async throws {
         let now = Date()
         let taggedNote = Note(
             id: UUID(), title: "Tagged Note", body: "Content with #project tag",
@@ -461,7 +461,7 @@ final class NotesViewsTests: XCTestCase {
         XCTAssertFalse(viewModel.allTagsList.isEmpty)
     }
 
-    func testNoteTagBadgesRender() async throws {
+    func testSmoke_NoteTagBadgesRender() async throws {
         let now = Date()
         let taggedNote = Note(
             id: UUID(), title: "Tagged Note", body: "Content with #design tag",

--- a/Tests/NotesUITests/ThemeTests.swift
+++ b/Tests/NotesUITests/ThemeTests.swift
@@ -7,12 +7,12 @@ import XCTest
 final class ThemeTests: XCTestCase {
     // MARK: - DueDateStyle
 
-    func testDueDateStyleReturnsOrangeForToday() {
+    func testSmoke_DueDateStyleReturnsOrangeForToday() {
         let color = DueDateStyle.color(for: Date())
         XCTAssertEqual(color, .orange, "Today's date should return orange")
     }
 
-    func testDueDateStyleReturnsRedForOverdue() throws {
+    func testSmoke_DueDateStyleReturnsRedForOverdue() throws {
         let yesterday = try XCTUnwrap(Calendar.current.date(byAdding: .day, value: -1, to: Date()))
         let color = DueDateStyle.color(for: yesterday)
         XCTAssertEqual(color, .red, "Overdue date should return red")
@@ -32,7 +32,7 @@ final class ThemeTests: XCTestCase {
 
     // MARK: - TaskStatus.accentColor
 
-    func testTaskStatusAccentColors() {
+    func testSmoke_TaskStatusAccentColors() {
         XCTAssertEqual(TaskStatus.backlog.accentColor, .gray)
         XCTAssertEqual(TaskStatus.next.accentColor, .blue)
         XCTAssertEqual(TaskStatus.doing.accentColor, .orange)
@@ -52,7 +52,7 @@ final class ThemeTests: XCTestCase {
 
     // MARK: - DNCardModifier
 
-    func testDNCardModifierAppliesWithDefaultRadius() {
+    func testSmoke_DNCardModifierAppliesWithDefaultRadius() {
         let view = Text("Test").dnCard()
         XCTAssertNotNil(view, "dnCard modifier should apply without crashing")
     }
@@ -76,7 +76,7 @@ final class ThemeTests: XCTestCase {
 
     // MARK: - DNGlassCardModifier
 
-    func testDNGlassCardModifierDefaultProperties() {
+    func testSmoke_DNGlassCardModifierDefaultProperties() {
         let modifier = DNGlassCardModifier()
         XCTAssertEqual(modifier.cornerRadius, 10, "Default corner radius should be 10")
         XCTAssertFalse(modifier.isDropTarget, "Default drop target should be false")

--- a/Tests/NotesUITests/UICoverageGapTests.swift
+++ b/Tests/NotesUITests/UICoverageGapTests.swift
@@ -35,7 +35,7 @@ final class UICoverageGapTests: XCTestCase {
 
     // MARK: - §1 Empty States — Fresh Install
 
-    func testFreshInstallNotesListEmpty() async {
+    func testSmoke_FreshInstallNotesListEmpty() async {
         let viewModel = makeViewModel()
         await viewModel.load()
 
@@ -63,7 +63,7 @@ final class UICoverageGapTests: XCTestCase {
 
     // MARK: - §8 Filter Edge Cases
 
-    func testFilterUpcomingReturnsFutureDatedTasks() async throws {
+    func testSmoke_FilterUpcomingReturnsFutureDatedTasks() async throws {
         let tomorrow = try XCTUnwrap(Calendar.current.date(byAdding: .day, value: 1, to: Date()))
         let task = try Task(
             stableID: "upcoming-task",
@@ -214,7 +214,7 @@ final class UICoverageGapTests: XCTestCase {
 
     // MARK: - §18 Recurrence Dialog Lifecycle
 
-    func testRecurrenceEditPromptNilInitially() async throws {
+    func testSmoke_RecurrenceEditPromptNilInitially() async throws {
         let viewModel = try makePopulatedViewModel()
         await viewModel.load()
 
@@ -272,7 +272,7 @@ final class UICoverageGapTests: XCTestCase {
 
     // MARK: - §19 Error Banner Lifecycle
 
-    func testErrorBannerAppearsAndClears() async throws {
+    func testSmoke_ErrorBannerAppearsAndClears() async throws {
         let viewModel = try makePopulatedViewModel()
         await viewModel.load()
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -11,4 +11,7 @@ echo -n "$STAGED" | xargs -0 swiftformat --lint --config .swiftformat
 echo "==> SwiftLint (staged files)"
 echo -n "$STAGED" | xargs -0 swiftlint lint --strict --config .swiftlint.yml
 
+echo "==> Smoke tests (staged changes)"
+swift test --filter testSmoke 2>&1 | tail -3
+
 echo "✓ Pre-commit checks passed"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -11,7 +11,6 @@ echo -n "$STAGED" | xargs -0 swiftformat --lint --config .swiftformat
 echo "==> SwiftLint (staged files)"
 echo -n "$STAGED" | xargs -0 swiftlint lint --strict --config .swiftlint.yml
 
-echo "==> Smoke tests (staged changes)"
-swift test --filter testSmoke 2>&1 | tail -3
+"$(git rev-parse --show-toplevel)"/Scripts/run-smoke-tests.sh
 
 echo "✓ Pre-commit checks passed"

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-echo "==> Coverage gates (pre-push)"
-./Scripts/run-coverage-gates.sh


### PR DESCRIPTION
## Summary

- Rename 108 selected tests across 21 files to use `testSmoke_` prefix, enabling `swift test --filter testSmoke` as a fast ~160-test smoke subset (~2.5s execution / <5s wall)
- Add `Scripts/run-smoke-tests.sh` wrapper script
- Wire smoke tests into `hooks/pre-commit` (runs after lint)
- Remove `hooks/pre-push` (full suite + coverage gates becomes manual local CI)
- Add `smoke` job to `.github/workflows/coverage-gates.yml`
- Update `CLAUDE.md` with new commands and validation protocol step

## Test plan

- [x] `swift test --filter testSmoke` — 160 tests pass in ~2.5s
- [x] `swift test` — full 466 tests still pass, no tests lost
- [x] `./Scripts/run-smoke-tests.sh` — works standalone
- [x] `./Scripts/run-lint.sh` — no lint violations from renames
- [x] Coverage gates — identical results before/after (pre-existing failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)